### PR TITLE
Update standards version to 4

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Build-Depends: debhelper (>= 13),
                dh-python,
                python3 (>= 3.4),
                python3-distutils
-Standards-Version: 4.1.4
+Standards-Version: 4.1.5
 Testsuite: autopkgtest-pkg-python
 
 Package: python3-pypeg2


### PR DESCRIPTION
Update standards version to 4.1.5, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))

This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/pypeg2/67e201af-1bcc-49b1-bbf5-d29e00ea6a56.
